### PR TITLE
Allow inheritance of test classes. 

### DIFF
--- a/t/fixtures/inherit-testclass.it
+++ b/t/fixtures/inherit-testclass.it
@@ -1,0 +1,98 @@
+#! perl
+
+package My::Inherit::Parent;
+use Test2::Tools::xUnit;
+use Test2::V0;
+
+# keep track of event details so that we can ensure that all of the
+# tests and todos ran.  Because the results are unordered, the tests
+# check if an event is in a set.  This list is used to ensure that
+# events aren't duplicated (e.g., that I haven't messed up).
+
+our @EVENTS;
+
+sub emit {
+
+    my $ctx = context;
+    my $self = shift;
+    my $details = join( '::', @_  );
+    push @EVENTS, $details;
+
+    $ctx->send_ev2_and_release( assert => { pass => 1, details => $details  } );
+    return;
+};
+
+sub BeforeAll_Parent : BeforeAll  {
+    shift->emit( __PACKAGE__, 'BeforeAll' );
+}
+
+sub AfterAll_Parent : AfterAll {
+    shift->emit( __PACKAGE__, 'AfterAll' );
+}
+
+sub BeforeEach_Parent : BeforeEach  {
+    shift->emit( __PACKAGE__, 'BeforeEach' );
+}
+
+sub AfterEach_Parent : AfterEach {
+    shift->emit( __PACKAGE__, 'AfterEach' );
+}
+
+sub Test_Parent : Test {
+    shift->emit( __PACKAGE__, 'Test' );
+}
+
+sub Skip_Parent : Skip {
+    shift->emit( __PACKAGE__, 'Skip' );
+}
+
+sub Todo_Parent : Todo {
+    shift->emit( __PACKAGE__, 'Todo' );
+}
+
+package My::Inherit::Child;
+
+use Test2::V0;
+
+use parent -norequire => 'My::Inherit::Parent';
+
+sub BeforeAll_Child : BeforeAll  {
+    shift->emit( __PACKAGE__, 'BeforeAll' );
+}
+
+sub AfterAll_Child : AfterAll {
+    shift->emit( __PACKAGE__, 'AfterAll' );
+}
+
+sub BeforeEach_Child : BeforeEach  {
+    shift->emit( __PACKAGE__, 'BeforeEach' );
+}
+
+sub AfterEach_Child : AfterEach {
+    shift->emit( __PACKAGE__, 'AfterEach' );
+}
+
+sub Test_Child : Test {
+    shift->emit( __PACKAGE__, 'Test' );
+}
+
+sub Skip_Child : Skip {
+    shift->emit( __PACKAGE__, 'Skip' );
+}
+
+sub Todo_Child : Todo {
+    shift->emit( __PACKAGE__, 'Todo' );
+}
+
+
+package My::Inherit::SubChild;
+
+use Test2::V0;
+
+use parent -norequire => 'My::Inherit::Child';
+
+done_testing;
+
+1;
+
+

--- a/t/inherit-testclass.t
+++ b/t/inherit-testclass.t
@@ -1,0 +1,138 @@
+#! perl
+
+use Test2::V0;
+use Test2::API 'intercept';
+
+my $events = intercept {
+    if ( !defined( do "./t/fixtures/inherit-testclass.it" ) ) {
+        die $@ unless $@ eq '';
+        die $!;
+    }
+};
+
+my @events = @$events;
+
+sub check_event {
+    my ( $where, $what, $package ) = @_;
+
+    $package ||= $where;
+    event(
+        'V2' => sub {
+            call facet_data => hash {
+                field assert => hash {
+                    field details => "My::Inherit::${where}::${what}";
+                    etc;
+                };
+                etc;
+            };
+            prop package => "My::Inherit::${package}";
+        } );
+}
+
+sub check_subtest {
+
+    my ( $where, $what ) = @_;
+
+    return event(
+        'Subtest' => sub {
+            call subevents => array {
+                check_event( 'Parent' => 'BeforeEach' );
+                check_event( 'Child'  => 'BeforeEach' );
+                check_event( $where   => $what );
+                check_event( 'Parent' => 'AfterEach' );
+                check_event( 'Child'  => 'AfterEach' );
+                event( 'Plan' );
+                end();
+            }
+        } );
+}
+
+# first two events are the BeforeAll events from the parent and child
+# classes
+is(
+    $events[0],
+    check_event( Parent => 'BeforeAll', 'SubChild' ),
+    "Parent BeforeAll"
+);
+
+is(
+    $events[1],
+    check_event( Child => 'BeforeAll', 'SubChild' ),
+    "Child BeforeAll"
+);
+
+
+# last three events are cleanup and plan
+
+is(
+    $events[-3],
+    check_event( Parent => 'AfterAll', 'SubChild' ),
+    "Parent AfterAll"
+);
+is(
+    $events[-2],
+    check_event( Child => 'AfterAll', 'SubChild' ),
+    "Child AfterAll"
+);
+
+is( $events[-1], event( 'Plan' ), "Plan" );
+
+
+# intermediate events are subtests, skips, or todos, in random order.
+
+my @set = (
+    check_subtest( Parent => 'Todo' ),
+    check_subtest( Parent => 'Test' ),
+    check_subtest( Child  => 'Todo' ),
+    check_subtest( Child  => 'Test' ),
+    event(
+        Skip => sub {
+            call name => 'Skip_Parent';
+        }
+    ),
+    event(
+        Skip => sub {
+            call name => 'Skip_Child';
+        }
+    ),
+);
+
+
+for my $event ( @events[ 2 .. ( @events - 4 ) ] ) {
+    is( $event, in_set( @set ), "Event" );
+}
+
+
+# i've forgotten how to get Perl not to give a used only once error
+# for a specific variable
+no warnings 'once';
+
+is(
+    \@My::Inherit::Parent::EVENTS,
+    bag {
+        item "My::Inherit::Parent::BeforeAll";
+        item "My::Inherit::Child::BeforeAll";
+
+        for ( 1 .. 4 ) {
+            item "My::Inherit::Child::AfterEach";
+            item "My::Inherit::Child::BeforeEach";
+            item "My::Inherit::Parent::AfterEach";
+            item "My::Inherit::Parent::BeforeEach";
+        }
+
+        item "My::Inherit::Child::Test";
+        item "My::Inherit::Child::Todo";
+
+        item "My::Inherit::Parent::Test";
+        item "My::Inherit::Parent::Todo";
+
+        item "My::Inherit::Parent::AfterAll";
+        item "My::Inherit::Child::AfterAll";
+
+        end;
+    },
+    "Got the expected events"
+);
+
+
+done_testing;


### PR DESCRIPTION
  For example,
```
package Parent;
use Test2::Tools::xUnit;
use Test2::V0;

sub setup : BeforeAll { };
sub cleanup : AfterAll { };

sub test0 : Test { };

package Child;
use parent Parent;

sub setup : BeforeAll { };
sub cleanup : AfterAll { };

sub test1 : Test { };

done_testing;
```

will run

```
Parent::setup;
Child::setup;

# arbitrary order
test0;
test1;

# yes, this order looks inverted, but that's the order it's run
Parent::cleanup;
Child::cleanup;
```
Parent calss teardown methods are always run before child's, as they are registered
with Test2 first. Conventions can remediate this, for instance,

```
 package Parent;

 sub AfterAll { } # no attributes!

 package Child;
 use parent 'Parent';

 sub AfterAll :AfterAll {

      # perform Child teardown
      ...

      # move up the inheritance chain
      Child->SUPER::AfterAll;
 }
```